### PR TITLE
kickico.co & bllttrex.com

### DIFF
--- a/_data/data.yaml
+++ b/_data/data.yaml
@@ -13469,3 +13469,11 @@
     url: 'https://bittrex.ltd'
     category: Phishing
     subcategory: Bittrex
+-
+    id: 2158
+    name: kickico.co
+    url: 'http://kickico.co'
+    category: Phishing
+    subcategory: KICKICO
+    addresses:
+      - '0xc5d65deff5d1373f8b19aa8be528e9c3599013ba'

--- a/_data/data.yaml
+++ b/_data/data.yaml
@@ -13477,3 +13477,9 @@
     subcategory: KICKICO
     addresses:
       - '0xc5d65deff5d1373f8b19aa8be528e9c3599013ba'
+-
+    id: 2159
+    name: bllttrex.com
+    url: 'https://bllttrex.com'
+    category: Phishing
+    subcategory: Bittrex


### PR DESCRIPTION
Reported via etherscan disqus (moderation queue) - confirmed site is cloned of kickico.com (most pages redirect to there except the ico - gives a non-contract address also)