### PR TITLE
starbase.pro & herotokens.io & omise.com.co

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -13580,3 +13580,9 @@
     subcategory: EtherDelta
     addresses:
       - '0x7CBC4E0D168744912C5Afc081499145BBDc51e69'
+-
+    id: 2174
+    name: starbase.pro
+    url: 'http://starbase.pro'
+    category: Phishing
+    subcategory: Starbase

--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -13594,3 +13594,9 @@
     subcategory: Hero
     addresses:
       - '0x57b818a1070373e21fcedf48d4368e1703c75852'
+-
+    id: 2176
+    name: omise.com.co
+    url: 'https://omise.com.co'
+    category: Phishing
+    subcategory: OmiseGO

--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -13586,3 +13586,11 @@
     url: 'http://starbase.pro'
     category: Phishing
     subcategory: Starbase
+-
+    id: 2175
+    name: herotokens.io
+    url: 'https://herotokens.io'
+    category: Phishing
+    subcategory: Hero
+    addresses:
+      - '0x57b818a1070373e21fcedf48d4368e1703c75852'


### PR DESCRIPTION
starbase.pro

Fake starbase.co site. Phishing for funds.

https://tokenmarket.net/blockchain/ethereum/assets/starbase/
https://twitter.com/StarbaseCo/status/905231250125864960

---

herotokens.io

see: https://github.com/409H/EtherAddressLookup/commit/6207370a662d2850c7376f42f8b4f4ccf58bc3f8

---

omise.com.co

Fake omiseGO site. Airdrop form with classic `sign.php` for the private key.