### PR TITLE
protostokenhub.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -14206,3 +14206,11 @@
     url: 'http://myetherwallets.co/'
     category: Phishing
     subcategory: MyEtherWallet
+-
+    id: 2265
+    name: protostokenhub.com
+    url: 'http://protostokenhub.com/'
+    category: Phishing
+    subcategory: Protos
+    addresses:
+      - '0xd92559E1F1d2E84F4964F45256693D03833D7D44'


### PR DESCRIPTION
fake https://protos.tokenhub.com/ crowdsale site - reported by GriffGreen