### PR TITLE
etherdelta.su

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -14376,4 +14376,9 @@
     subcategory: Cobinhood
     addresses:
       - '0x920aDc9A060cdA345fdEc2fdeBAd6EBF38eDf83D'
-      
+-
+    id: 2293
+    name: etherdelta.su
+    url: 'http://etherdelta.su/'
+    category: Phishing
+    subcategory: EtherDelta


### PR DESCRIPTION
Fake EtherDelta

> This message was shared on all Slack channels in the hope of reaching as many EtherDelta traders as possible.
> 
> Due to the recent security flaw discovered on our servers ( https://medium.com/@rleshner/security-vulnerability-etherdelta-10556d6e72a ), we are asking all our users to remove their private keys from EtherDelta until we issue a hotfix. 
Complying to these measures will ensure the security of your account and the safety of your funds.  
> 
> Please visit https://etherdelta.github.io#removekeys to securely remove your account from our servers.
> 
> We are sorry for any inconvenience this might cause you, but we are taking security seriously and  we are assuring you that our team is working around the clock to issue a hotfix. 
> 
> We will keep you updated on the progress.
> 
> Thank you for your cooperation and understanding,
> 
> The EtherDelta Team