### PR TITLE
Update scams with privatix.pro latest scam

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -14884,3 +14884,11 @@
     subcategory: MyEtherWallet
     addresses:
       - '0x62404BFB3e1c464f17e3AF0c139e39D0703ae4A1'  
+- 
+    id: 2369
+    name: privatix.pro 
+    url: 'http://privatix.pro/'
+    category: Phishing
+    subcategory: Privatix
+    addresses:
+      - '0x071cf579507DD0661845694F709E68CF7Ea506a4' 


### PR DESCRIPTION
Hello,
This is a phishing site against Privatix.
Phishing site: http://privatix.pro
Original site: https://privatix.io

Technical details:
Domain creation date: Yesterday (2017-10-20)
Domain holder: No details - Privacy  Protected, and under CloudFlare
Malicious content: The attacker change the wallet address to his own wallet address - trying to steal money. (https://etherscan.io/address/0x071cf579507DD0661845694F709E68CF7Ea506a4)

More Details:
http://privatix.pro is an impersonating site, aiming to phish customers of Privatix, which is now in the middle of an ICO (selling digital currency). 
Their original website is under https://privatix.io. 

Privatix confirmed this is not their site.

http://privatix.pro had been purchased yesterday (Oct 20), and behind CloudFlare.
This is the 3rd impersonation attack on them in the last couple of days (previous ones were with privatix[.]live and privatex[.]io

The wallet address of the attacker is 0x071cf579507DD0661845694F709E68CF7Ea506a4
and it is different than the wallet address of the ICO (which started on Oct 19), and thus stealing investors money!!!