### PR TITLE
utrust.so

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -15152,3 +15152,11 @@
     url: 'http://myethierwallet.org/'
     category: Phishing
     subcategory: MyEtherWallet
+-
+    id: 2406
+    name: utrust.so
+    url: 'http://utrust.so/'
+    category: Phishing
+    subcategory: Utrust
+    addresses:
+      - '0x8A46Aa04725b2E2029bdCb924D671Fd6a9c11daB'


### PR DESCRIPTION
Fake utrust.io crowdsale site.
Google Ad
address: 0x8A46Aa04725b2E2029bdCb924D671Fd6a9c11daB
https://urlscan.io/result/d5c7821f-7985-416e-9883-24aca61734ea/#summary

https://github.com/409H/EtherAddressLookup/commit/bd85254d84f78ae8f393ea8471c865132b1396da