### PR TITLE
xn--coinelegraph-wk5f.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -16969,3 +16969,10 @@
     category: Phishing
     subcategory: Appcoinsproject
     description: 'Fake Appcoinsproject airdrop site asking for private keys'  
+-
+    id: 2642
+    name: xn--coinelegraph-wk5f.com
+    url: 'http://xn--coinelegraph-wk5f.com'
+    category: Scamming
+    subcategory: Cointelegraph
+    description: 'Fake cointelegraph promoting fake airdrops'


### PR DESCRIPTION
Fake cointelegraph promoting fake airdrops - promoting `xn--os-g7s.com`

https://urlscan.io/result/dfe4ef7b-ec72-483c-bb4f-61c218a948c2#summary