### PR TITLE
tgram.cc and grampreico.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -17418,3 +17418,19 @@
     description: 'Fake Telegram crowdsale site'
     addresses:
       - '0x8202b590Eca4662446102b3a97E3536aAc8ab941'
+-
+    id: 2700
+    name: grampreico.com
+    url: 'http://grampreico.com'
+    category: Phishing
+    subcategory: Telegram
+    description: 'Fake Telegram crowdsale site'
+    addresses:
+      - '0x26F7Eb488661C33c43089aD61944f3231222b32f'
+-
+    id: 2701
+    name: tgram.cc
+    url: 'http://tgram.cc'
+    category: Phishing
+    subcategory: Telegram
+    description: 'Fake Telegram site'   


### PR DESCRIPTION
grampreico.com
Fake Telegram crowdsale site
https://urlscan.io/result/946380cf-37a9-48ee-8c24-f5746a01724c/#summary
address: 0x26F7Eb488661C33c43089aD61944f3231222b32f

tgram.cc
Fake Telegram ICO site
https://urlscan.io/result/fe30f20e-6cd9-4603-85b5-903e154eec1b/#summary