### PR TITLE
wwwkodakcoin.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -17918,3 +17918,10 @@
     category: Phishing
     subcategory: MyEtherWallet
     description: 'Fake MyEtherWallet'
+-
+    id: 2761
+    name: wwwkodakcoin.com
+    url: 'http://wwwkodakcoin.com'
+    category: Phishing
+    subcategory: Kodak
+    description: 'Fake kodakcoin domain (www.kodakcoin.com) redirecting to a binance referral. Blacklisted for worst case.'


### PR DESCRIPTION
Fake kodakcoin domain (www.kodakcoin.com) redirecting to a binance referral. Blacklisted for worst case.

https://urlscan.io/result/e8731acf-e3a9-4637-a0b0-84426e9e0009#summary