### PR TITLE
block.chaiins.in

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -17988,3 +17988,10 @@
     category: Phishing
     subcategory: Origin
     description: 'Fake Origin Token airdrop site phishing for private keys'
+-
+    id: 2771
+    name: https://block.chaiins.in
+    url: 'http://block.chaiins.in'
+    category: Phishing
+    subcategory: Blockchain
+    description: 'Fake Blockchain web wallet'


### PR DESCRIPTION
Fake blockchain.info website

urlscan cannot resolve it, neither can I.

```
Non-authoritative answer:
Name:    block.chaiins.in
Address:  128.199.45.227
```

![image](https://user-images.githubusercontent.com/2313704/35644662-737a30ee-06c1-11e8-9c89-31bcd4a8da4a.png)