### PR TITLE
token-gram.org

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -18058,3 +18058,12 @@
     category: Phishing
     subcategory: Shapeshift
     description: 'Fake Shapeshift - IDN homograph attack'     
+-
+    id: 2781
+    name: https://token-gram.org
+    url: 'http://token-gram.org'
+    category: Phishing
+    subcategory: Telegram
+    description: 'Fake Telegram token crowdsale site'
+    addresses:
+      - '0xb2172027cb233198A3945A2c864f1Ec5b7E3b3Da' 


### PR DESCRIPTION
Fake Telegram crowdsale site

address: 0xb2172027cb233198A3945A2c864f1Ec5b7E3b3Da

https://twitter.com/durov/status/944360557318205440?ref_src=twsrc%5Etfw&ref_url=https%3A%2F%2Ftechcrunch.com%2F2018%2F01%2F20%2Ftelegram-ico-scammers%2F

see https://github.com/MetaMask/eth-phishing-detect/pull/783