### PR TITLE
decentral.market

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -18328,3 +18328,12 @@
     category: Scamming
     subcategory: Giveaway
     description: 'Fake giveaway, asks you for a deposit for gas funds'
+-
+    id: 2813
+    name: https://decentral.market
+    url: 'https://decentral.market'
+    category: Phishing
+    subcategory: News
+    description: 'Fake news site publishing ICOs with fake contribution addresses'
+    addresses:
+      - '0xdefb014b9e2f3bd81cdb084821f99b681cfca695' 


### PR DESCRIPTION
decentral.market is a fake cryptocurrency news website that posts articles from other sites. When it copies ICO participation guides, it replaces the contribution address with a different address.

Example: Arcblock and Republic Protocol have the same Ethereum address (0xdefb014b9e2f3bd81cdb084821f99b681cfca695).

https://urlscan.io/result/13e72351-ec0c-4ea0-89b4-c2b9e3031197#summary

see https://github.com/409H/EtherAddressLookup/pull/282