### PR TITLE
promo-give-ethereum.org + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -24634,3 +24634,39 @@
     category: Phishing
     subcategory: Forkdelta
     description: 'Fake ForkDelta'    
+-
+    id: 3586
+    name: promo-give-ethereum.org
+    url: 'http://promo-give-ethereum.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x7D922A4f7F24fFcb130c4EEAF291A6475e3e4Dd2'     
+-
+    id: 3587
+    name: give-ethereum.org
+    url: 'http://give-ethereum.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x7D922A4f7F24fFcb130c4EEAF291A6475e3e4Dd2' 
+-
+    id: 3588
+    name: ethereum-giveaway.site
+    url: 'http://ethereum-giveaway.site'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x299628fD380813622305517E64eee89BB6a49Ca3'       
+-
+    id: 3589
+    name: twitter.com/Aurora__dao/status/960683836463075328
+    url: 'https://twitter.com/Aurora__dao/status/960683836463075328'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam tweet'
+    addresses:
+      - '0xfa2e4bddb3899dFB0d91A70744739d9f76692755'             


### PR DESCRIPTION
promo-give-ethereum.org
Trust-trading scam site. Promoted by Twitter ID: 992951433690398720 (@Aurora_dao_)
https://urlscan.io/result/9cfea787-9e9c-4308-ac22-6ab050e87034/
address:  0x7D922A4f7F24fFcb130c4EEAF291A6475e3e4Dd2

give-ethereum.org
Trust-trading scam site. Promoted by medium-give-ethereum[dot]org and Twitter ID: 992951433690398720 (@Aurora_dao_)
https://urlscan.io/result/407e88cd-8108-4192-8053-8ef3836dcca8
https://urlscan.io/result/265b0fbe-0276-4253-8843-c393d3e475ad/
address:  0x7D922A4f7F24fFcb130c4EEAF291A6475e3e4Dd2

ethereum-giveaway.site
Trust-trading scam site. Promoted by Twitter ID: 132293081 (@Aurora___dao)
https://urlscan.io/result/e107a9cd-bc1b-41f7-8f39-c51c4d2749c5
address:  0x299628fD380813622305517E64eee89BB6a49Ca3

https://twitter.com/Aurora__dao/status/960683836463075328
Trust-trading scam tweet
https://urlscan.io/result/bf95638a-4d18-4c59-aa0b-58a304c5c1a4/
address:  0xfa2e4bddb3899dFB0d91A70744739d9f76692755