### PR TITLE
telegram-token.io + icostats.io

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -24832,3 +24832,19 @@
     category: Phishing
     subcategory: Yobit
     description: 'Fake Yobit login'
+-
+    id: 3610
+    name: telegram-token.io
+    url: 'https://telegram-token.io'
+    category: Phishing
+    subcategory: Telegram
+    description: 'Fake Telegram crowdsale site - see https://twitter.com/sniko_/status/994604991187996672'
+    addresses:
+      - '0x52bEF206E8e0403Cd60d37E48f4F3860D9545556' 
+-
+    id: 3611
+    name: icostats.io
+    url: 'https://icostats.io'
+    category: Scamming
+    subcategory: Icostats
+    description: 'Fake Icostats site promoting a fake Telegram crowdsale site'      


### PR DESCRIPTION
telegram-token.io
Fake Telegram crowdsale site
https://urlscan.io/result/0aec803b-c326-4ca4-ad12-3d1fa1598f87
https://urlscan.io/result/bae9712f-b5ce-465b-8ac6-df6f613d2da7
https://twitter.com/sniko_/status/994604991187996672
address:  0x52bEF206E8e0403Cd60d37E48f4F3860D9545556

icostats.io
Fake Icostats site promoting a fake Telegram site, using ICODrops twitter unfurl data
https://urlscan.io/result/d668399e-b22b-4d6d-aa28-2c25e7661ba5/