### PR TITLE
ethgiveaway.zkr.kr + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -26826,3 +26826,28 @@
     category: Phishing
     subcategory: Eos
     description: 'Fake Eos airdrop phishing for private keys'        
+-
+    id: 3856
+    name: ethgiveaway.zkr.kr
+    url: 'https://ethgiveaway.zkr.kr'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x9852286460022e5151381361bA4271c7272cF966'
+-
+    id: 3857
+    name: eth-promo.wixsite.com
+    url: 'https://eth-promo.wixsite.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x9852286460022e5151381361bA4271c7272cF966'      
+-
+    id: 3858
+    name: calchain.io
+    url: 'https://calchain.io'
+    category: Phishing
+    subcategory: Airdrop
+    description: 'Fake airdrop emailing users to go to signupform1.typeform.com via email, which then directs them to xn--myetherwalt-kbb96i.com'     


### PR DESCRIPTION
ethgiveaway.zkr.kr
Trust trading scam site
https://urlscan.io/result/6a755409-20bc-48b9-8af2-b21b10b2dfb5/
address: 0x9852286460022e5151381361bA4271c7272cF966

eth-promo.wixsite.com
Trust trading scam site
https://urlscan.io/result/9a662a44-7d02-459f-86b6-76a81e2cc6da/
address: 0x9852286460022e5151381361bA4271c7272cF966

calchain.io
Fake airdrop emailing users to go to signupform1.typeform.com via email, which then directs them to xn--myetherwalt-kbb96i.com
https://urlscan.io/result/4192662f-9496-4572-a45c-b24143ff721b/
https://urlscan.io/result/2ca50f69-3fd0-4e91-8cc2-4502977e7e2b/