### PR TITLE
ethpromo.cc + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -28003,3 +28003,26 @@
     category: Phishing
     subcategory: EOS
     description: 'Fake EOS countdown, phishing for private keys with POST /VerifyToken.php' 
+-
+    id: 4001
+    name: ethpromo.cc
+    url: 'http://ethpromo.cc'
+    category: Phishing
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x05e85D73Eaf6fEF228294fdF867aBBa98552A99F' 
+-
+    id: 4002
+    name: idex-market.eu
+    url: 'https://idex-market.eu'
+    category: Phishing
+    subcategory: Idex
+    description: 'Fake Idex market phishing keys'      
+-
+    id: 4003
+    name: idex-login.net
+    url: 'https://idex-login.net'
+    category: Phishing
+    subcategory: Idex
+    description: 'Fake Idex market phishing keys'          


### PR DESCRIPTION
ethpromo.cc
Trust trading scam site
https://urlscan.io/result/77f317d7-44a8-4774-affc-f1303fc1a409/
address: 0x05e85D73Eaf6fEF228294fdF867aBBa98552A99F

idex-market.eu
Fake idex phishing for keys
https://urlscan.io/result/4fbd0c72-4bca-47eb-890a-8197a14a1a42/

idex-login.net
Fake idex phishing for keys
https://urlscan.io/result/7b3fe2c9-cefe-4463-886c-d4dd3cdd0623/