### PR TITLE
ethereum.website.tk + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -28441,3 +28441,19 @@
     description: 'Trust-Trading site'
     addresses:
       - '0x916d37534f95f30c35A60a58150F48c2D0fF4Be2'
+-
+    id: 4055
+    name: ethereum.website.tk
+    url: 'https://ethereum.website.tk'
+    category: Trust-Trading
+    description: 'Trust-Trading site'
+    addresses:
+      - '0x0E2fA227599b1701cEEEcfBF0c92d8D23b2F493e'
+-
+    id: 4056
+    name: blttrex.us
+    url: 'https://blttrex.us'
+    category: Trust-Trading
+    description: 'Trust-Trading site'
+    addresses:
+      - '0x92d43D2f55E077D1beBC6e348a9F4FF64fD4F21A'      


### PR DESCRIPTION
ethereum.website.tk
Trust trading scam site
https://urlscan.io/result/5b2b4fa8-e28e-4ec7-bc2b-6fcdef12551b
address: 0x0E2fA227599b1701cEEEcfBF0c92d8D23b2F493e

ethereum-bonus.com
Trust trading scam site
https://urlscan.io/result/bc0f3c67-c250-4fe1-8763-3e699d199f19/
address: 0x916d37534f95f30c35A60a58150F48c2D0fF4Be2

blttrex.us
Trust trading scam site
https://urlscan.io/result/036952c2-98a8-4388-924e-ee0e50d54ee8/
address: 0x92d43D2f55E077D1beBC6e348a9F4FF64fD4F21A