### PR TITLE
Fix addresses get api

### DIFF
--- a/run.js
+++ b/run.js
@@ -554,7 +554,7 @@ function startWebServer() {
                 var blocked = false;
                 Object.keys(getCache().addresses).forEach(function(address, index) {
                     //They searched for an address
-                    if (req.params.domain == address) {
+                    if (req.params.domain.toLowerCase() == address.toLowerCase()) {
                         blocked = true;
                         res.send(JSON.stringify({
                             success: true,

--- a/run.js
+++ b/run.js
@@ -554,7 +554,7 @@ function startWebServer() {
                 var blocked = false;
                 Object.keys(getCache().addresses).forEach(function(address, index) {
                     //They searched for an address
-                    if (req.params.domain.toLowerCase() == address.toLowerCase()) {
+                    if (req.params.domain.toLowerCase() === address.toLowerCase()) {
                         blocked = true;
                         res.send(JSON.stringify({
                             success: true,

--- a/run.js
+++ b/run.js
@@ -562,7 +562,7 @@ function startWebServer() {
                             type: 'address',
                             entries: getCache().scams.filter(function(scam) {
                                 if ('addresses' in scam) {
-                                    return (scam.addresses.includes(req.params.domain));
+                                    return (scam.addresses.includes(req.params.domain.toLowerCase()));
                                 } else {
                                     return false;
                                 }

--- a/update.js
+++ b/update.js
@@ -41,6 +41,12 @@ scams.forEach(function(scam, index) {
             console.log('Warning! Entry ' + scam.id + ' has no protocol (http or https) specified. Please update!');
             scam.url = 'http://' + scam.url;
         }
+        if (scam.addresses != null) {
+          scam.addresses.forEach(function(address, index) {
+            //console.log("Casting " + scam.addresses[index] + " as " + scam.addresses[index].toLowerCase())
+            scam.addresses[index] = scam.addresses[index].toLowerCase();
+          })
+        }
         var scam_details = new_cache.scams[new_cache.scams.push(scam) - 1];
         new_cache.blacklist.push(url.parse(scam.url).hostname.replace("www.", ""));
         new_cache.blacklist.push('www.' + url.parse(scam.url).hostname.replace("www.", ""));
@@ -118,10 +124,11 @@ scams.forEach(function(scam, index) {
                     }
                     if ('addresses' in scam_details) {
                         scam_details.addresses.forEach(function(address) {
-                            if (!(address in new_cache.addresses)) {
-                                new_cache.addresses[address] = [];
+                            if (!(address.toLowerCase() in new_cache.addresses)) {
+                                new_cache.addresses[address.toLowerCase()] = [];
                             }
-                            new_cache.addresses[address] = scam_details.toLowerCase;
+                            //console.log(new_cache.addresses);
+                            new_cache.addresses[address.toLowerCase()] = scam_details;
                         });
                     }
 					scams_checked++;

--- a/update.js
+++ b/update.js
@@ -121,7 +121,7 @@ scams.forEach(function(scam, index) {
                             if (!(address in new_cache.addresses)) {
                                 new_cache.addresses[address] = [];
                             }
-                            new_cache.addresses[address] = scam_details;
+                            new_cache.addresses[address] = scam_details.toLowerCase;
                         });
                     }
 					scams_checked++;


### PR DESCRIPTION
Casts addresses as lowercase in the cache and display to allow for /api/check/ for addresses functionality to be case-insensitive.

Fixes #927 

Now lowercase and uppercase addresses in api both return the same content: 
![lowercase](https://user-images.githubusercontent.com/29407814/41193708-2350eb94-6bde-11e8-8955-2f502f294d00.PNG)

![uppercase](https://user-images.githubusercontent.com/29407814/41193710-25b20116-6bde-11e8-92be-e625568f1639.PNG)

