### PR TITLE
creteprint-driveways.co.uk + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -29344,3 +29344,30 @@
     category: Phishing
     subcategory: Idex
     description: 'Fake Idex Market'         
+-
+    id: 4171
+    name: creteprint-driveways.co.uk
+    url: 'http://creteprint-driveways.co.uk'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x607c78AeAaBADb84AdC3298fb3077fc75429e8bD'     
+-
+    id: 4172
+    name: ethype.org
+    url: 'http://ethype.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0xB9b848702a47AE78A70D18c45e552aB1637B5908'           
+-
+    id: 4173
+    name: etherpromotion.org
+    url: 'http://etherpromotion.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x32Ea6b24675349EDb6dF2896457819289Aad180E'            


### PR DESCRIPTION
creteprint-driveways.co.uk
Trust trading scam site
https://urlscan.io/result/fc1a6bf3-235d-458e-a55f-85c1a8d6a88f
address: 0x607c78AeAaBADb84AdC3298fb3077fc75429e8bD

ethype.org
Trust trading scam site
https://urlscan.io/result/6f03f717-aa58-4b9f-a92c-0b88c0e78d1b/
address: 0xB9b848702a47AE78A70D18c45e552aB1637B5908

etherpromotion.org
Trust trading scam site
https://urlscan.io/result/f67991dc-a3e4-4221-b9bf-ef59c39850f7/
address: 0x32Ea6b24675349EDb6dF2896457819289Aad180E