### PR TITLE
ethpromoaction.com + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -29388,3 +29388,30 @@
     category: Phishing
     subcategory: Idex
     description: 'Stealing seed phrases. Fake EOS register'         
+-
+    id: 4177
+    name: ethpromoaction.com
+    url: 'http://ethpromoaction.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0xBee06db915F38C62D61aBa80932369007bEAe9d8'   
+-
+    id: 4178
+    name: ethinfo.org
+    url: 'http://ethinfo.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x34b6341655061f4B5830CD1a7B20A3516043AF57'         
+-
+    id: 4179
+    name: airgws.org
+    url: 'http://airgws.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0xc364451d6316Be34CB1b8f8B0922fE59d5CF2Ca9'           


### PR DESCRIPTION
ethpromoaction.com
Trust trading scam site
https://urlscan.io/result/e3492e92-5d7a-42e8-ad25-5c9252f03281/
address: 0xBee06db915F38C62D61aBa80932369007bEAe9d8

ethinfo.org
Trust trading scam site
https://urlscan.io/result/c447f9e1-028c-4ade-a59e-400ac2dbb767/
address: 0x34b6341655061f4B5830CD1a7B20A3516043AF57

airgws.org
Trust trading scam site
https://urlscan.io/result/01d49f90-753a-4483-a517-d35b894e5ff7/
address: 0xc364451d6316Be34CB1b8f8B0922fE59d5CF2Ca9