### PR TITLE
masterthecrypto.org + xn--myetherwllet-ncb.org

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -29415,3 +29415,17 @@
     description: 'Trust trading scam site'
     addresses:
       - '0xc364451d6316Be34CB1b8f8B0922fE59d5CF2Ca9'           
+-
+    id: 4180
+    name: masterthecrypto.org
+    url: 'http://masterthecrypto.org'
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Directing users to a fake MyEtherWallet (https://bitly.com/2sK9fJW+) - xn--myetherwllet-ncb.org'    
+-
+    id: 4181
+    name: xn--myetherwllet-ncb.org
+    url: 'http://xn--myetherwllet-ncb.org'
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Fake MyEtherWallet - IDN homograph attack domain'        


### PR DESCRIPTION
masterthecrypto.org
Directing users to a fake MyEtherWallet (https://bitly.com/2sK9fJW+) - xn--myetherwllet-ncb.org
https://urlscan.io/result/7e09ccd6-f3cb-4f1a-bf23-cf4f639ccadc/
https://urlscan.io/result/e453d4e4-7cad-4be7-ba2a-5f87f47a533b/

xn--myetherwllet-ncb.org
Fake MyEtherWallet - IDN homograph attack domain
https://urlscan.io/result/53853539-5bdd-4458-9b3d-3f03d496d94c/