### PR TITLE
binance-giveaway.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -29574,3 +29574,12 @@
     description: 'Fake GoNetwork crowdsale site'
     addresses:
       - '0x65403AA21fbE76cC8eDcd42ECdD0C6Cc5C972F73' 	      
+-
+    id: 4201
+    name: binance-giveaway.com
+    url: 'https://binance-giveaway.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site' 
+    addresses:
+      - '0x15B4E32d5026A5A9Ad3b68BEcAdceB00B4eB9729'      


### PR DESCRIPTION
binance-giveaway.com
Trust trading scam site
https://urlscan.io/result/79b97afe-c7e8-4712-9962-e5a12d7bf561/
address: 0x15B4E32d5026A5A9Ad3b68BEcAdceB00B4eB9729