### PR TITLE
Fixed eth address Search

### DIFF
--- a/_layouts/search.html
+++ b/_layouts/search.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="/css/search.css">
-<h1><i class="search icon"></i> Check URL</h1>
+<h1><i class="search icon"></i> Check URL / IP / ETH Address</h1>
 <div id='verified' class="ui icon message">
     <i class="checkmark icon"></i>
     <div class="content">
@@ -27,9 +27,9 @@
         <p id='neutralmessage'>This domain wasn't recognized as a malicious domain, nor as verified. Be careful!</p>
     </div>
 </div>
-<p id='helpmessage'>Enter an URL to check whether you can trust it or not.</p>
+<p id='helpmessage'>Enter a URL, IP address, or ETH address to check whether you can trust it or not.</p>
 <div class="ui action input">
-    <input type="text" placeholder="https://mycrypto.com">
+    <input type="text" placeholder="mycrypto.com / 1.1.1.1 / 0x0000000000000000000000000000000000000000">
     <button class="ui button">Check</button>
 </div>
 <h1>Trusted domains</h1>

--- a/_static/js/search.js
+++ b/_static/js/search.js
@@ -27,11 +27,11 @@ window.addEventListener("load", function() {
                     $("#blacklistmessage").html(encodeURI($("input").val().toLowerCase().replace('http://','').replace('https://','').replace('www.','').split(/[/?#]/)[0]) + ' was put on the blacklist for ' + result.entries[0].category.toLowerCase() + '.');
                     strLink = '<a id="details" href="/scam/' + result.entries[0].id + '">Details <i class="chevron right small icon"></i></a>';
                 } else if(result.type == 'address') {
-					          $("#blacklistmessage").html(encodeURI($("input").val().toLowerCase().replace('http://','').replace('https://','').replace('www.','').split(/[/?#]/)[0]) + ' was put on the blacklist and is associated with '+ result.entries.length +' blocked domain(s)');
-					          strLink = '<a id="details" href="/address/' + result.input + '">Details <i class="chevron right small icon"></i></a>';
+					          $("#blacklistmessage").html(encodeURI($("input").val().toLowerCase()) + ' was put on the blacklist and is associated with '+ result.entries.length +' blocked domain(s).');
+					          strLink = '<a id="details" href="/address/' + encodeURI($("input").val()) + '">Details on this address <i class="chevron right small icon"></i></a>';
 				        } else if(result.type == 'ip') {
 					          $("#blacklistmessage").html(encodeURI($("input").val().toLowerCase().replace('http://','').replace('https://','').replace('www.','').split(/[/?#]/)[0]) + ' was put on the blacklist and is associated with '+ result.entries.length +' blocked domain(s)');
-					          strLink = '<a id="details" href="/ip/' + result.input + '">Details <i class="chevron right small icon"></i></a>';
+					          strLink = '<a id="details" href="/ip/' + encodeURI($("input").val()) + '">Details <i class="chevron right small icon"></i></a>';
 				        }
                 $("#blacklistmessage").html($("#blacklistmessage").html() + ' ' + strLink);
                 $("#blocked").css('display', 'flex');


### PR DESCRIPTION
Fixed the eth address search to link correctly. Previously, it was just linking to `/address/undefined`. Also edited the UI for users to know that they can search for more than just domains.

Fixed: #950 

![from a ui perspective](https://user-images.githubusercontent.com/29407814/41502997-e7ddbf8e-7195-11e8-9b83-ce6d65c166a8.PNG)
