### PR TITLE
Added whitelist api GET for ETH addresses from legit_urls

### DIFF
--- a/_data/legit_urls.yaml
+++ b/_data/legit_urls.yaml
@@ -3,6 +3,8 @@
     name: MyCrypto
     url: 'https://mycrypto.com'
     featured: true
+    addresses:
+      - '0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520'
 -
     id: 2
     name: MetaMask
@@ -31,6 +33,8 @@
     name: Etherscan
     url: 'https://etherscan.io'
     featured: true
+    addresses:
+      - '0x71c7656ec7ab88b098defb751b7401b5f6d8976f'
 -
     id: 8
     name: EtherID

--- a/_layouts/address.html
+++ b/_layouts/address.html
@@ -1,9 +1,9 @@
 <link rel="stylesheet" href="/css/address.css">
 <h1>{{ address.address }}</h1>
-<div class="ui mini red message"><i class="warning sign icon"></i> Warning: Do not send money to this address</div>
+{{ address.notification }}
 <b>Balance</b>: <span id="balance">loading...</span><BR>
 <b>USD Value</b>: <span id="value">loading...</span><BR>
-<b>Related to the following scams</b>: {{ address.scams }}
+{{ address.list }}
 <div class="ui divider"></div>
 <a target="_blank" href="https://etherscan.io/address/{{ address.address }}"><i class="external icon"></i> View address on etherscan</a><BR>
 

--- a/_static/js/search.js
+++ b/_static/js/search.js
@@ -19,6 +19,13 @@ window.addEventListener("load", function() {
                 $("#neutralmessage").html(encodeURI($("input").val().toLowerCase().replace('http://','').replace('https://','').replace('www.','').split(/[/?#]/)[0]) + ' wasn\'t recognized as a malicious domain, nor as verified domain. Be careful!');
                 $("#neutralmessage").html($("#neutralmessage").html());
                 $("#neutral").css('display', 'flex');
+            } else if (result.result == 'whitelisted') {
+                hideEverything();
+                var strLink = '';
+                $("#verifiedmessage").html(encodeURI($("input").val().toLowerCase().replace('http://','').replace('https://','').replace('www.','').split(/[/?#]/)[0]) + ' is a whitelisted address. You can trust it.');
+                strLink = '<a id="details" href="/address/' + encodeURI($("input").val()) + '">Details on this address <i class="chevron right small icon"></i></a>';
+                $("#verifiedmessage").html($("#verifiedmessage").html() + ' ' + strLink);
+                $("#verified").css('display', 'flex');
             } else if (result.result == 'blocked') {
                 hideEverything();
                 blocked = true;

--- a/run.js
+++ b/run.js
@@ -596,6 +596,24 @@ function startWebServer() {
             //They can search for an address or domain.
             if (/^0x?[0-9A-Fa-f]{40,42}$/.test(req.params.domain)) {
                 var blocked = false;
+                Object.keys(getCache().whitelistaddresses).forEach(function(address, index) {
+                    //They searched for an address
+                    if (req.params.domain.toLowerCase() === address.toLowerCase()) {
+                        blocked = true;
+                        res.send(JSON.stringify({
+                            success: true,
+                            result: 'whitelisted',
+                            type: 'address',
+                            entries: getCache().legiturls.filter(function(verified) {
+                                if ('addresses' in verified) {
+                                    return (verified.addresses.includes(req.params.domain.toLowerCase()));
+                                } else {
+                                    return false;
+                                }
+                            })
+                        }));
+                    }
+                });
                 Object.keys(getCache().addresses).forEach(function(address, index) {
                     //They searched for an address
                     if (req.params.domain.toLowerCase() === address.toLowerCase()) {

--- a/run.js
+++ b/run.js
@@ -620,7 +620,7 @@ function startWebServer() {
                         blocked = true;
                         res.send(JSON.stringify({
                             success: true,
-                            result: 'verified',
+                            result: 'whitelisted',
                             type: 'address',
                             entries: getCache().legiturls.filter(function(verified) {
                                 if ('addresses' in verified) {

--- a/run.js
+++ b/run.js
@@ -529,6 +529,7 @@ function startWebServer() {
         let template = fs.readFileSync('./_layouts/address.html', 'utf8');
         template = template.replace(/{{ address.address }}/g, req.params.address);
         var related = '';
+        var whitelistrelated = '';
         getCache().scams.filter(function(obj) {
             if ('addresses' in obj) {
                 return obj.addresses.includes(req.params.address);
@@ -536,9 +537,26 @@ function startWebServer() {
                 return false;
             }
         }).forEach(function(value) {
+            template = template.replace("{{ address.notification }}", '<div class="ui mini red message"><i class="warning sign icon"></i> Warning: Do not send money to this address</div>')
+            template = template.replace("{{ address.list }}", "<b>Related to the following verified scams</b>: {{ address.scams }}")
             related += "<div class='item'><a href='/scam/" + value.id + "/'>" + value.name + "</div>";
         });
+
+        getCache().legiturls.filter(function(objtwo) {
+            if ('addresses' in objtwo) {
+                return objtwo.addresses.includes(req.params.address.toLowerCase());
+            } else {
+                return false;
+            }
+        }).forEach(function(valuetwo) {
+            template = template.replace("{{ address.notification }}", '<div class="ui mini green message"><i class="warning sign icon"></i> This is a verified address</div>')
+            template = template.replace("{{ address.list }}", "<b>Related to the following verified urls</b>: {{ address.verifieddomains }}")
+            whitelistrelated += "<div class='item'><a href='" + valuetwo.url + "/'>" + valuetwo.name + " - (" + valuetwo.url + ")" + "</div>";
+
+        });
+
         template = template.replace("{{ address.scams }}", '<div class="ui bulleted list">' + related + '</div>');
+        template = template.replace("{{ address.verifieddomains }}", '<div class="ui bulleted list">' + whitelistrelated + '</div>');
         res.send(default_template.replace('{{ content }}', template));
     });
 

--- a/run.js
+++ b/run.js
@@ -620,7 +620,7 @@ function startWebServer() {
                         blocked = true;
                         res.send(JSON.stringify({
                             success: true,
-                            result: 'whitelisted',
+                            result: 'verified',
                             type: 'address',
                             entries: getCache().legiturls.filter(function(verified) {
                                 if ('addresses' in verified) {

--- a/update.js
+++ b/update.js
@@ -16,6 +16,7 @@ let new_cache = {
     'legiturls': [],
     'blacklist': [],
     'addresses': {},
+    'whitelistaddresses': {},
     'ips': {},
     'whitelist': [],
     'inactives': [],
@@ -31,8 +32,21 @@ yaml.safeLoad(fs.readFileSync('_data/legit_urls.yaml')).sort(function(a, b) {
     return a.name - b.name;
 }).forEach(function(legit_url) {
     new_cache.legiturls.push(legit_url);
+
     new_cache.whitelist.push(url.parse(legit_url.url).hostname.replace("www.", ""));
     new_cache.whitelist.push('www.' + url.parse(legit_url.url).hostname.replace("www.", ""));
+    if ('addresses' in legit_url) { // (if 'addresses' exists in legit_urls)
+        legit_url.addresses.forEach(function(whitelistaddress) {
+            if (!(whitelistaddress.toLowerCase() in new_cache.whitelistaddresses)) {
+                new_cache.whitelistaddresses[whitelistaddress.toLowerCase()] = [];
+            }
+            var currwhitelistindex = whitelistaddress.toLowerCase();
+            new_cache.whitelistaddresses[currwhitelistindex] = legit_url;
+            for(var i = 0 ; i < new_cache.whitelistaddresses[currwhitelistindex].addresses.length; i++){
+                new_cache.whitelistaddresses[currwhitelistindex].addresses[i] = new_cache.whitelistaddresses[currwhitelistindex].addresses[i].toLowerCase();
+            }
+        });
+    }
 });
 setInterval(function() {
     console.log(scams_checked + '/' + scams.length + ' (' + requests_pending + ' requests pending)');


### PR DESCRIPTION
Added GET ability on /api/check for ETH addresses that have been whitelisted in legit_urls.yaml

![whitelist api return](https://user-images.githubusercontent.com/29407814/41824106-1f26ee4a-77d9-11e8-914c-afb57e6707c4.PNG)

Also added to template for endpoints `/address/<address>` to show verified urls:

![new addresses page](https://user-images.githubusercontent.com/29407814/41857255-0fe9030a-7865-11e8-9058-93f03c71a57e.PNG)

