### PR TITLE
eosauthorithy.com + ethereumanniversary.org

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -31561,3 +31561,18 @@
     category: Phishing
     subcategory: EOS
     description: 'Fake EOS domain - IDN homograph attack domain - phishing for private keys'      
+-
+    id: 4438
+    name: eosauthorithy.com
+    url: 'https://eosauthorithy.com'
+    category: Phishing
+    subcategory: EOS
+    description: 'Fake EOS web wallet. Stealing private keys with POST /store.php'
+-
+    id: 4439
+    name: ethereumanniversary.org
+    url: 'https://ethereumanniversary.org'
+    category: Scamming
+    subcategory: 'Trust trading scam site'
+    addresses:
+    - '0xAF5bDa8f8b954b03474305FD148c8361CaD4D2cD'


### PR DESCRIPTION
eosauthorithy.com
Fake EOS domain - phishing for private keys with POST /store.php
https://urlscan.io/result/e09358b9-6ae8-4a67-aaf2-14ddc2fd6561

ethereumanniversary.org
Trust trading scam site
https://urlscan.io/result/5780b378-df75-49c5-8459-c6d178a5a4bd
address: 0xaec2Cc8986BB14C0C604d5Adf725BA33920102bc