### PR TITLE
removed  id: 2992

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -19757,15 +19757,6 @@
     addresses:    
       - '0x0Dea8A35F4E39cDF65d3cC11f10612E9E0278b60'
 -            
-    id: 2992
-    name: geocities.ws
-    url: 'http://geocities.ws'
-    category: Scamming
-    subcategory: Trust-trading
-    description: 'Trust-Trading scam'    
-    addresses:    
-      - '0x2b5268FDE5041f6B1Afd77166De4e9eA5D9e967a'
--            
     id: 2993
     name: xn--binnce-y0a.com
     url: 'http://xn--binnce-y0a.com'


### PR DESCRIPTION
wrongly detected site geocities.ws
http://geocities.ws is web hosting service, the format of the user's url is geocities.ws/USERNAME