### PR TITLE
hydrogen-raindrop.bitballoon.com + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -33283,3 +33283,17 @@
     category: Scamming
     subcategory: Trust-Trading
     description: 'Reported trust trading scam site. Reported address: 0x9E91ea0C442dd2B41CC7fE2d54fAEcd34f59C134'      
+-
+    id: 4645
+    name: hydrogen-raindrop.bitballoon.com
+    url: https://hydrogen-raindrop.bitballoon.com
+    category: Phishing
+    subcategory: HYDRO
+    description: 'Fake airdrop form directing users to a fake MyEtherWallet - www.myetherwallet.ethersignmsg.services via https://bit.ly/2ufxyjC'
+-
+    id: 4646
+    name: myetherwallet.ethersignmsg.services
+    url: 'http://www.myetherwallet.ethersignmsg.services'
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Fake MyEtherWallet'


### PR DESCRIPTION
hydrogen-raindrop.bitballoon.com
Pishing site directing to a fake MEW (via https://bit.ly/2ufxyjC).
Originating from fake telegram channel t.me/project_hydro.
https://urlscan.io/result/eeb4035c-909f-4ca8-9af8-96b17e62cd2f

myetherwallet.ethersignmsg.services
Fake MEW.
https://urlscan.io/result/9ca25375-249c-4d6f-ad5b-66d8cba8a0ce