### PR TITLE
bittrexl.com + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -33365,3 +33365,33 @@
     description: 'Trust trading scam site'
     addresses:    
       - '0xfDFf5c88B7ce9b45037C360C380904e780DE17A4'         
+-
+    id: 4656
+    name: bittrexl.com
+    url: 'https://bittrexl.com'
+    category: Phishing
+    subcategory: Bittrex
+    description: 'Fake Bittrex phishing for logins'     
+-
+    id: 4657
+    name: idex.xyz
+    url: 'https://idex.xyz'
+    category: Phishing
+    subcategory: Idex
+    description: 'Fake Idex phishing for keys with POST /sendkey.php'      
+-
+    id: 4658
+    name: teslagifts.tumblr.com
+    url: 'https://teslagifts.tumblr.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Promoting trust trading scam sites directing users to http://etherclaims22.top/payment.php'
+    addresses:    
+      - '0xAB7EC7596fc05BC55AFc07008cC06c1193eD6f9a'     
+-
+    id: 4659
+    name: brinannce.com
+    url: 'https://brinannce.com'
+    category: Phishing
+    subcategory: Binance
+    description: 'Fake Binance phishing for logins'         


### PR DESCRIPTION
bittrexl.com
Fake Bittrex login phishing for logins
https://urlscan.io/result/bdb5571d-e320-4d83-9a21-718c0b45cefa
https://urlscan.io/result/826e053b-78ec-4d5a-9d56-f5fce55372e9

idex.xyz
Fake Idex phishing for keys with POST /sendkey.php
https://urlscan.io/result/f8ab0ddb-1e86-4f9d-89e4-074a663d8fd8/

teslagifts.tumblr.com
Promoting trust trading scam sites directing users to http://etherclaims22.top/payment.php
https://urlscan.io/result/d4bf8844-4e8c-4a19-a670-97ca05d8da8a/
address: 0xAB7EC7596fc05BC55AFc07008cC06c1193eD6f9a

brinannce.com
Fake Binance phishing for logins
https://urlscan.io/result/8f424bbb-6ae1-4c41-8540-75ded8c985c7/
https://urlscan.io/result/8de488f7-df50-498c-941d-7358943117ab/