### PR TITLE
refundcontract-etherwallet.net + idexr.market

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -34010,3 +34010,17 @@
     category: Phishing
     subcategory: Idex
     description: 'Fake Idex site phishing for keys'   
+-
+    id: 4735
+    name: refundcontract-etherwallet.net
+    url: 'https://refundcontract-etherwallet.net'
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Fake MyEtherWallet. Users redirected over email via https://bitly.com/2L3Ua1a+'   
+-
+    id: 4736
+    name: idexr.market
+    url: 'https://idexr.market'
+    category: Phishing
+    subcategory: Idex
+    description: 'Fake Idex market phishing for keys'       


### PR DESCRIPTION
refundcontract-etherwallet.net
Fake MyEtherWallet. Users redirected over email via https://bitly.com/2L3Ua1a+
https://urlscan.io/result/6b13d39e-005e-40bd-ae29-b45bfc88573b/


idexr.market
Fake Idex market phishing for keys
https://urlscan.io/result/e4951908-3628-491f-98d0-961ebbb422dc/
https://urlscan.io/result/b2db3889-9b3e-48b3-8226-38c284c4ff8d/