### PR TITLE
idex-market.biz.pl + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -35191,7 +35191,7 @@
     name: idex-market.trade
     url: 'https://idex-market.trade'
     category: Phishing
-    subcategory: MyEtherWallet
+    subcategory: Idex
     description: 'Fake Idex phishing for keys'      
 -
     id: 4881
@@ -35407,3 +35407,37 @@
     description: 'Trust trading scam site'
     addresses:
       - '0x6128c3095e2b0A64CE64e10F05B60d5029e5F8eC'       
+-
+    id: 4905
+    name: idex-market.biz.pl
+    url: 'https://idex-market.biz.pl'
+    category: Phishing
+    subcategory: Idex
+    description: 'Fake Idex phishing for keys'    
+-
+    id: 4906
+    name: getethereumforfree.com
+    url: 'http://getethereumforfree.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0xC7566BA63f39bA75B56EAdc0328F9A76Dbd1ADf3'      
+-
+    id: 4907
+    name: medium-hitbtc.tumblr.com
+    url: 'http://medium-hitbtc.tumblr.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x8C500BD17174e8604ff9aD3399bD13af245EeF52'          
+-
+    id: 4908
+    name: ethereum-return.com
+    url: 'http://ethereum-return.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+      - '0x8C500BD17174e8604ff9aD3399bD13af245EeF52'         


### PR DESCRIPTION
idex-market.biz.pl
Fake Idex market phishing for keys
https://urlscan.io/result/203a5dfa-5488-4956-b219-3a0dc039b917
https://urlscan.io/result/8b2e6516-ffcd-481b-a7b8-dcaa29d037f3

getethereumforfree.com
Trust trading scam site
https://urlscan.io/result/80a28520-7403-442a-b235-f5467e12e626/
address: 0xC7566BA63f39bA75B56EAdc0328F9A76Dbd1ADf3

medium-hitbtc.tumblr.com
Trust trading scam site linking to http://ethereum-return.com/hitbtc/payment.php
https://urlscan.io/result/5b63be29-8112-4707-b451-5f96bf72b1df/
address: 0x8C500BD17174e8604ff9aD3399bD13af245EeF52

ethereum-return.com
Trust trading scam site
https://urlscan.io/result/491ef95c-935f-4541-8a1e-24d207bfea45/
https://urlscan.io/result/f47b89a0-f631-43be-8ed6-885234acf4de/
address: 0x8C500BD17174e8604ff9aD3399bD13af245EeF52