### PR TITLE
medeum-airdrop-news.com + ethereum-transfer.net

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -36586,3 +36586,21 @@
     category: Phishing
     subcategory: MyEtherWallet
     description: 'Fake MyEtherWallet (now hosting a coindesk view)'        
+-
+    id: 5044
+    name: medeum-airdrop-news.com
+    url: 'http://medeum-airdrop-news.com'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'     
+    addresses:
+      - '0x43FA247764BfBe1Beba49111e4ed215524f02c41' 
+-
+    id: 5045
+    name: ethereum-transfer.net
+    url: 'http://ethereum-transfer.net'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'     
+    addresses:
+      - '0x43FA247764BfBe1Beba49111e4ed215524f02c41'       


### PR DESCRIPTION
medeum-airdrop-news.com
Trust trading scam site - linking users to ethereum-transfer.net
https://urlscan.io/result/f163756e-08db-46b1-8528-bcb749d4e6e5/
address: 0x43FA247764BfBe1Beba49111e4ed215524f02c41

ethereum-transfer.net
Trust trading scam site
https://urlscan.io/result/d84279a4-9e1e-414f-a5c3-9752f89c88a3/
address: 0x43FA247764BfBe1Beba49111e4ed215524f02c41