### PR TITLE
bittrex-sigin.com

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -36989,6 +36989,7 @@
     addresses:
       - '0xBb802918Bc1Ac6089315f951F2b60a1CC275c3Bb'  
       - '0xc86619343080fa921baaff201c91dbbe8ceffa9e'
+      - '0xe1228F81C01b80EfeFAC957483d63a40c6d635e1'
 -
     id: 5095
     name: giftsforyou.online
@@ -38041,3 +38042,10 @@
     description: 'Trust trading scam site'     
     addresses:
       - '0xe889b0d59fd4181857edb19f5fecafa8510f2fad'  
+-
+    id: 5219
+    name: bittrex-sigin.com
+    url: 'http://bittrex-sigin.com'
+    category: Phishing
+    subcategory: Bittrex
+    description: 'Fake Bittrex phishing for logins with POST /verification.php'     


### PR DESCRIPTION
bittrex-sigin.com
Fake Bittrex phishing for logins with POST /verification.php
https://urlscan.io/result/9875a705-35da-420a-bc8a-0c643d0db6dc/


---

giveaway.ether-claim.org
Trust trading scam site
https://urlscan.io/result/4d447289-a35d-43cf-a885-b4a0a44eee71/
address: 0xe1228F81C01b80EfeFAC957483d63a40c6d635e1