### PR TITLE
musk-air.org + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -38209,3 +38209,35 @@
     description: 'Trust trading scam site'     
     addresses:
       - '0x31fca2139b07c2a97287de51f0219a34f4181710'               
+-
+    id: 5238
+    name: musk-air.org
+    url: 'http://musk-air.org'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'     
+    addresses:
+      - '0x72696cE345abB71398384e42CfbF6C9A995246c0'   
+-
+    id: 5239
+    name: safe-claims.info
+    url: 'http://safe-claims.info'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'     
+    addresses:
+      - '0x6a9c2ec4f4888d7338fc1b28584aaafeb01e6db3'         
+-
+    id: 5240
+    name: bitstamp.pw
+    url: 'http://bitstamp.pw'
+    category: Phishing
+    subcategory: Bitstamp
+    description: 'Fake Bitstamp exchange phishing for logins with POST /_indexSend.php'         
+-
+    id: 5241
+    name: binance-web.com
+    url: 'http://binance-web.com'
+    category: Phishing
+    subcategory: Binance
+    description: 'Fake Binance exchange phishing for logins with POST /_indexSend.php'      


### PR DESCRIPTION
musk-air.org
Trust trading scam site
https://urlscan.io/result/2dd66c5f-1860-440f-a21c-ea6b6869975d/
address: 0x72696cE345abB71398384e42CfbF6C9A995246c0

safe-claims.info
Trust trading scam site. Linking users to giveawaypromo.byethost14.com
https://urlscan.io/result/eb1d9dd5-6af9-452e-9eda-66278a02eddf/
address: 0x6a9c2ec4f4888d7338fc1b28584aaafeb01e6db3

bitstamp.pw
Fake Bitstamp exchange phishing for logins with POST /_indexSend.php
https://urlscan.io/result/eb5baf6a-4170-4502-986d-1dd07bc6abf5/
https://urlscan.io/result/5e607e6b-d132-4aec-b78b-d1789cefdc42

binance-web.com
Fake Binance exchange phishing for logins with POST /_loginSend.php
https://urlscan.io/result/61e8fd01-eaa0-45d0-a9a3-98cd6160ec25/
https://urlscan.io/result/b259851a-d380-4d5d-8ea3-6b128776ad03/