### PR TITLE
eth-claim.pw + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -39259,3 +39259,26 @@
     description: 'Trust trading scam site'     
     addresses:
       - '0xb6591bbfdd9aDfE48F174E741c35119b08b02E60'             
+-
+    id: 5363
+    name: eth-claim.pw
+    url: 'http://eth-claim.pw'
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'     
+    addresses:
+      - '0x4D1DCFbF1299EB1007d55976754bb41a87eb9D0F'   
+-
+    id: 5364
+    name: xn--tronscn-mwa.com
+    url: 'http://xn--tronscn-mwa.com'
+    category: Phishing
+    subcategory: Tron
+    description: 'Fake Tronscan phishing for keys with POST /auth.php'        
+-
+    id: 5365
+    name: tron-scan.info
+    url: 'http://tron-scan.info'
+    category: Phishing
+    subcategory: Tron
+    description: 'Fake Tronscan phishing for keys (redirecting to xn--tronscn-mwa.com)'         


### PR DESCRIPTION
eth-claim.pw
Trust trading scam site
https://urlscan.io/result/73a07fe4-9426-4b11-942b-7c08b36ca480
address: 0x4D1DCFbF1299EB1007d55976754bb41a87eb9D0F

xn--tronscn-mwa.com
Fake Tronscan phishing for keys with POST /auth.php
https://urlscan.io/result/a1eb8d1b-d9ac-42ed-9a6b-e51c61dec208/

tron-scan.info
Fake Tronscan phishing for keys (redirecting to xn--tronscn-mwa.com)
https://urlscan.io/result/fa7e0bf6-18c5-4b40-89fa-aa76f9460e41/