### PR TITLE
international.bittrex.com8917321.ga + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -58752,3 +58752,39 @@
     addresses:
         - '0x3C98B49694c18ab0492A048eE213e2c3d3B3e0Ff'
     reporter: MyCrypto             
+-
+    id: 6198
+    name: international.bittrex.com8917321.ga
+    url: 'http://international.bittrex.com8917321.ga'
+    coin: ETH
+    category: Phishing
+    subcategory: Bittrex
+    description: 'Fake Bittrex phishing for logins - https://twitter.com/ANeilan/status/1069746687550386177'
+    reporter: MyCrypto       
+-
+    id: 6199
+    name: cryptophonesupport.com
+    url: 'http://cryptophonesupport.com'
+    coin: ETH
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Fake phone support for multiple cryptocurrency products'
+    reporter: MyCrypto       
+-
+    id: 6200
+    name: keepstake.github.io 
+    url: 'http://keepstake.github.io'
+    coin: ETH
+    category: Phishing
+    subcategory: MetaMask
+    description: 'Phishing for MetaMask phrases with POST web3.keepstake.io/process.php'
+    reporter: MyCrypto         
+-
+    id: 6201
+    name: msg.xn--metherwllt-zmb5581g94a.com
+    url: 'http://msg.xn--metherwllt-zmb5581g94a.com'
+    coin: ETH
+    category: Phishing
+    subcategory: MyEtherWallet
+    description: 'Fake MyEtherWallet phishing for keys with POST /process.php'
+    reporter: MyCrypto           


### PR DESCRIPTION
international.bittrex.com8917321.ga
Fake Bittrex phishing for logins -
https://twitter.com/ANeilan/status/1069746687550386177
https://urlscan.io/result/bc48e861-ec1a-4795-a8c5-aa7a004587a4/
https://urlscan.io/result/4127fcd8-d362-447f-b796-8cd025def2fd/

cryptophonesupport.com
Fake phone support for multiple cryptocurrency products
https://urlscan.io/result/50faf3dd-fc0e-45ad-b3f5-01665389ca9c/

keepstake.github.io
Phishing for MetaMask phrases with POST web3.keepstake.io/process.php
https://urlscan.io/result/7e1a1ce9-e680-4e28-b7e1-533344f0c36d

msg.xn--metherwllt-zmb5581g94a.com
Fake MyEtherWallet phishing for keys with POST /process.php
https://urlscan.io/result/824b459b-f0b9-4f8e-b058-27d29384e19c