### PR TITLE
cash-bitcoin.online + more

### DIFF
--- a/_data/scams.yaml
+++ b/_data/scams.yaml
@@ -59490,3 +59490,32 @@
     addresses:
         - 'ATVMaR3SXKRBtwCNgPjV5k2YzEgzMDYeaf'    
     reporter: MyCrypto           
+-
+    id: 6273
+    name: cash-bitcoin.online
+    url: 'http://cash-bitcoin.online'
+    coin: BTC
+    category: Scamming
+    subcategory: Trust-Trading
+    description: 'Trust trading scam site'
+    addresses:
+        - '3CnqzLzkrHwCoi94y8Caq2Yw1pQQA94Wvk'    
+    reporter: MyCrypto            
+-
+    id: 6274
+    name: yobit--net.com
+    url: 'http://yobit--net.com'
+    coin: ETH
+    category: Phishing
+    subcategory: YoBit
+    description: 'Fake Yobit phishing for logins with POST /en/_loginSend.php'
+    reporter: MyCrypto       
+-
+    id: 6275
+    name: supportyobit.net
+    url: 'http://supportyobit.net'
+    coin: ETH
+    category: Phishing
+    subcategory: YoBit
+    description: 'Fake YoBit phihsing for Yobicodes with POST /login.php'
+    reporter: MyCrypto        


### PR DESCRIPTION
cash-bitcoin.online
Trust trading scam site
https://urlscan.io/result/05ce8702-5326-4088-9294-3340319ac4fd/
address: 3CnqzLzkrHwCoi94y8Caq2Yw1pQQA94Wvk

yobit--net.com
Fake Yobit phishing for logins with POST /en/_loginSend.php
https://urlscan.io/result/57afad75-bfa0-4cb6-9f98-3c38cc6d8bbe/

supportyobit.net
Fake YoBit phihsing for Yobicodes with POST /login.php
https://urlscan.io/result/eb2706be-2677-4a5b-8ada-13a4c6a5367e/