### PR TITLE
Redirect XSS fix

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="/css/redirect.css">
 <h1><i class="warning sign icon"></i> Warning</h1>
-<h3>You are about to leave the official website to an untrusted domain.</h3>
+<h3>You are about to leave the official website to an external domain.</h3>
 <div class="ui divider"></div>
 <h3>Domain: <b id='domain'>{{ redirect.domain }}</b></h3>
 <div class="ui divider"></div>

--- a/run.js
+++ b/run.js
@@ -1068,6 +1068,41 @@ function startWebServer() {
     });
 
     app.get('/redirect/:url/', function(req, res) { // Serve /redirect/<url>/
+        var whitelistImports;
+        var blacklistImports;
+        var fuzzylistImports;
+        var toleranceImports;
+        let domainpage = req.params.url.toLowerCase();
+
+        console.log(/^((https?\:\/\/)?[0-9a-z\.\-]+)$/.exec(domainpage));
+        if(/^((https?\:\/\/)?[0-9a-z\.\-]+)$/.exec(domainpage) === null) {
+            let template = fs.readFileSync('./_layouts/404.html', 'utf8');
+            res.send(default_template.replace('{{ content }}', template));
+            return;
+        }
+
+        domainpage = domainpage.replace(/^(https?\:\/\/)/, '');
+        console.log(domainpage);
+
+        var webcheck = new check();
+        var urllookup = new lookup();
+        let startTime = (new Date()).getTime();
+
+        let scam = getCache().scams.find(function(scam) {
+            return scam.name == domainpage;
+        });
+
+        let verified = getCache().legiturls.find(function(verified) {
+            return verified.url.replace("https://", '') == domainpage;
+        });
+
+        // Domain is not indexed so don't attempt a redirect
+        if(typeof scam === "undefined" && typeof verified === "undefined") {
+            let template = fs.readFileSync('./_layouts/404.html', 'utf8');
+            res.send(default_template.replace('{{ content }}', template));
+            return;
+        }
+
         let template = fs.readFileSync('./_layouts/redirect.html', 'utf8').replace(/{{ redirect.domain }}/g, req.params.url);
         res.send(default_template.replace('{{ content }}', template));
     });


### PR DESCRIPTION
* Fixes XSS exploit - OBB 724561 (spam404)
   * Checks to make sure we have indexed the domain before we show the redirect view
       * 404s everything we haven't indexed - no leeching, we only want to give users the redirect to things we know about